### PR TITLE
style(aside): height

### DIFF
--- a/src/shared/components/Drawer/Aside/style/index.ts
+++ b/src/shared/components/Drawer/Aside/style/index.ts
@@ -5,7 +5,6 @@ export const Aside = styled("aside")<IAsideStyle>(
 	({ open, theme }) => `                
         position: relative;
         background-color: ${theme.palette.common.black};
-        height: 100vh;
         width: ${open ? theme.spacing(25) : theme.spacing(7)};
         padding: ${theme.spacing(2)};          
         transition: width 0.2s ease-out;


### PR DESCRIPTION
The height `aside` is wrong when menu open

![image](https://user-images.githubusercontent.com/53228013/211409654-da91b33f-f913-4246-969a-4b76426e897b.png)
