### PR TITLE
refactor(service): staleTime and cacheTime

### DIFF
--- a/src/modules/dashboard/Board/DialogEditBoard/DialogEditBoard.tsx
+++ b/src/modules/dashboard/Board/DialogEditBoard/DialogEditBoard.tsx
@@ -39,7 +39,6 @@ const DialogEditBoard = () => {
 	};
 	const optionQuery = {
 		onSuccess: onSuccessQuery,
-		cacheTime: 0,
 		retry: false,
 		enabled: false,
 	};

--- a/src/modules/notes/Note/DialogEditNote/DialogEditNote.tsx
+++ b/src/modules/notes/Note/DialogEditNote/DialogEditNote.tsx
@@ -47,7 +47,7 @@ const DialogEditNote: React.FC = () => {
 	const { refetch, isFetching: isLoading } = useQuery<IFetchSingleNote>(
 		["dialog_edit_note"],
 		fetchSingleNote,
-		{ cacheTime: 0, onSuccess: onSuccessFetchSingleNote, retry: false, enabled: false }
+		{ onSuccess: onSuccessFetchSingleNote, retry: false, enabled: false }
 	);
 
 	useEffect(() => {

--- a/src/modules/texts/Text/CardText/CardText.tsx
+++ b/src/modules/texts/Text/CardText/CardText.tsx
@@ -5,7 +5,6 @@ import { useParams, useNavigate  } from "react-router-dom";
 import { useContextText } from "../Context";
 import useDialogText from "../hooks/useDialogText";
 import CardTextView from "./CardTextView";
-import { ONE_HOUR_IN_MILLISECOND } from "./constant";
 import { fetchTexts, fetchCreateText } from "./service";
 
 const CardText: React.FC = () => {
@@ -19,7 +18,7 @@ const CardText: React.FC = () => {
 	const [ isCreatingText, setIsCreatingText ] = useState(false);
 
 	const { data, isFetching: isLoading } = useQuery(["texts", { variables: board_id }], () => fetchTexts(board_id),
-		{ cacheTime: ONE_HOUR_IN_MILLISECOND, onSuccess: ({ title }) => seTitleText(title) }
+		{ onSuccess: ({ title }) => seTitleText(title) }
 	);	
 	
 	useEffect(() => {data && seTitleText(data.title);}, [board_id]);

--- a/src/modules/texts/Text/CardText/constant/index.ts
+++ b/src/modules/texts/Text/CardText/constant/index.ts
@@ -1,1 +1,0 @@
-export const ONE_HOUR_IN_MILLISECOND = 60 * 60 * 1000;

--- a/src/shared/services/queryClient.ts
+++ b/src/shared/services/queryClient.ts
@@ -1,14 +1,15 @@
 import { QueryClient } from "@tanstack/react-query";
 
 const ONE_HOUR_IN_MILLISECOND = 1000 * 60 * 60;
-const ONE_SECOND_IN_MILLISECOND = 1000;
+const ONE_SECOND = 1000;
 
 const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			staleTime: ONE_HOUR_IN_MILLISECOND,
+			cacheTime: ONE_HOUR_IN_MILLISECOND,
 			retry: 3,	
-			retryDelay: ONE_SECOND_IN_MILLISECOND 		
+			retryDelay: ONE_SECOND 		
 		},
 	},
 });


### PR DESCRIPTION
Set the default time for `staleTime` and `cacheTime` to one hour.
Remove unnecessary cacheTime value in `useQuery`.

