### PR TITLE
fix: previous pagination button not making request

### DIFF
--- a/src/modules/dashboard/Board/components/Dialogs/DialogEditBoard/components/DialogBackground/DialogBackground.tsx
+++ b/src/modules/dashboard/Board/components/Dialogs/DialogEditBoard/components/DialogBackground/DialogBackground.tsx
@@ -60,8 +60,7 @@ const DialogBackground: React.FC = () => {
 	};
 
 	useEffect(() => {
-		const shouldFetchImages = query && pagination !== 1;
-		if (shouldFetchImages) dialogBackgroundSubmit();
+		if (query) dialogBackgroundSubmit();
 	}, [pagination]);
 
 	const menuScrollTop = () => {

--- a/src/modules/dashboard/Board/components/Dialogs/DialogEditBoard/components/DialogBackground/DialogBackgroundView.tsx
+++ b/src/modules/dashboard/Board/components/Dialogs/DialogEditBoard/components/DialogBackground/DialogBackgroundView.tsx
@@ -38,8 +38,7 @@ const DialogBackgroundView: React.FC<IDialogBackgroundView> = props => {
 	} = props;
 
 	return (
-		// Why backgroundimage lower case > Warning: React does not recognize the `backgroundImage` prop on a DOM element.
-		<DialogBackground backgroundimage={dialogBackgroundImage}>
+		<DialogBackground backgroundImage={dialogBackgroundImage}>
 			<Button
 				variant="contained"
 				size="small"

--- a/src/modules/dashboard/Board/components/Dialogs/DialogEditBoard/components/DialogBackground/dialog-background.style.ts
+++ b/src/modules/dashboard/Board/components/Dialogs/DialogEditBoard/components/DialogBackground/dialog-background.style.ts
@@ -3,11 +3,13 @@ import { Theme } from "@emotion/react";
 
 export interface IDialogBackgroundStyled {
 	theme?: Theme;
-	backgroundimage: string;
+	backgroundImage: string;
 }
 
-export const DialogBackground = styled("div")<IDialogBackgroundStyled>(
-	({ theme, backgroundimage }) => `
+export const DialogBackground = styled("div", {
+	shouldForwardProp: prop => prop !== "backgroundImage",
+})<IDialogBackgroundStyled>(
+	({ theme, backgroundImage }) => `
         width: 100%;
         height: ${theme.spacing(15)};
         background: #00000059;
@@ -18,7 +20,7 @@ export const DialogBackground = styled("div")<IDialogBackgroundStyled>(
         justify-content: end;
         align-items: baseline;
         
-        background-image: linear-gradient(#1a191a82, #1a191a82), url(${backgroundimage});
+        background-image: linear-gradient(#1a191a82, #1a191a82), url(${backgroundImage});
         background-repeat: no-repeat;
         background-size: cover;
         background-position: center;


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
<!-- If it resolves a specific issue, reference it as "Fixes #IssueNumber". -->
**Describe**
The "Previous" pagination button in the image selector is unresponsive because it's not triggering a request to load the previous set of images

This implementation follows the changes:
- Fix previous pagination button
- Refactor react warns that the `backgroundImage` prop is invalid for DOM elements

## Type of Change
<!-- Please check the options that apply: -->
- [ ] Feature
- [x] Fix
- [ ] Chore
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe):

## Screenshots
<!-- If your changes are visual, include screenshots to show the differences. -->
<!-- You can delete this section if not applicable. -->
Issue

[Screencast from 29-05-2025 17:41:59.webm](https://github.com/user-attachments/assets/f3fcbb68-7b38-4103-b123-1ec276882e29)


## Testing
<!-- Describe the testing you have done to ensure your changes work as expected. -->
<!-- Include any relevant test cases or steps to reproduce. -->
N/A
## Checklist
<!-- Make sure all of the following are completed: -->
- [ ] My code follows the project's coding standards.
- [x] I have tested my changes.
- [ ] I have updated the documentation.
- [x] My branch is up to date with the base branch.

## Additional Notes
<!-- Any additional information or context about the changes. -->
N/A
